### PR TITLE
Add Jest tests for internal quote email template

### DIFF
--- a/__tests__/internalQuoteEmailTemplate.test.ts
+++ b/__tests__/internalQuoteEmailTemplate.test.ts
@@ -1,0 +1,54 @@
+import { getInternalQuoteEmailTemplate } from '../app/utils/internalQuoteEmailTemplate'
+
+describe('getInternalQuoteEmailTemplate', () => {
+  const formData = {
+    fullName: 'John Doe',
+    email: 'john@example.com',
+    phone: '1234567890',
+    companyName: 'Acme Inc',
+    companyWebsite: 'https://acme.com',
+    industry: 'Tech',
+    businessStage: 'Startup',
+    businessGoals: 'Goals',
+    packageInterest: 'Tier 1',
+    additionalPackageDetails: 'Details',
+    additionalPackageDetailsMessage: 'Message',
+    keyComponents: 'Key components',
+    businessDocumentation: 'Docs',
+    deadline: 'Soon',
+    deadlineDate: '2024-01-01',
+    additionalDetails: 'Additional',
+    leadershipCount: '5',
+    leadershipChallenges: 'Challenges',
+    leadershipGoals: 'Lead Goals',
+    leadershipDevelopmentProgram: 'Yes',
+    operationalChallenges: 'Ops Challenges',
+    primaryObjectives: 'Objectives',
+    kpiMetrics: 'Metrics',
+    businessKeyObjectives: 'Objectives',
+    strategyDeckGoals: 'Goals',
+    strategyDeckFocus: 'Focus',
+    existingData: 'Yes',
+    teamStructureChallenges: 'Structure',
+    teamStructureGoals: 'Goals',
+    organizationalChart: 'Chart'
+  };
+
+  const services = [
+    'leadership_strategy',
+    'business_planning',
+    'operational_review',
+    'strategy_deck',
+    'team_structure'
+  ] as const;
+
+  services.forEach(service => {
+    test(`returns text and html for ${service}`, () => {
+      const result = getInternalQuoteEmailTemplate(formData, service);
+      expect(result).toHaveProperty('text');
+      expect(result).toHaveProperty('html');
+      expect(result.text).toBeTruthy();
+      expect(result.html).toBeTruthy();
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json'
+    }
+  },
+  testMatch: ['**/__tests__/**/*.test.ts']
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "NODE_ENV=development next dev",
     "build": "next build --no-lint",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@types/nodemailer": "^6.4.17",
@@ -29,6 +30,9 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.3"
   }
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
## Summary
- add Jest setup and config
- include test script in `package.json`
- create unit tests for `getInternalQuoteEmailTemplate`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e6a237148324a86e1929253fca55